### PR TITLE
Added scikit-image to conda install of travis yaml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ install:
   - git clone -b xraylib --single-branch --depth=1 https://github.com/tacaswell/conda-recipes.git ../conda-recipes
   - conda build ../conda-recipes/xraylib
   - conda install xraylib --use-local --yes
+  - conda install scikit-image --yes
   - python setup.py install
-  - conda install scikit-image
 
 
 script:


### PR DESCRIPTION
Apparently the --yes flag is important...
Turns out that if you don't add --yes to `conda package [install]`
then travis won't run because it's waiting for someone to
say 'yes, install this package i told you to install...'
